### PR TITLE
[feat] 판매내역 조회 기능

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,9 @@
+buildscript {
+    ext {
+        queryDslVersion = "5.0.0"
+    }
+}
+
 plugins {
     id 'java'
     id 'org.springframework.boot' version '3.2.9'
@@ -30,13 +36,19 @@ dependencies {
 
     implementation 'org.apache.commons:commons-lang3:3.9'
 
+    annotationProcessor 'org.projectlombok:lombok'
+
     // mapstruct
     implementation 'org.mapstruct:mapstruct:1.4.2.Final'
     annotationProcessor "org.mapstruct:mapstruct-processor:1.4.2.Final"
-    annotationProcessor(
-            'org.projectlombok:lombok',
-            'org.projectlombok:lombok-mapstruct-binding:0.1.0'
-    )
+    annotationProcessor 'org.projectlombok:lombok-mapstruct-binding:0.1.0'
+
+
+    // QueryDSL
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
@@ -48,3 +60,25 @@ dependencies {
 tasks.named('test') {
     useJUnitPlatform()
 }
+
+/** QueryDSL start **/
+
+// Querydsl 설정부
+def generated = 'product/build/querydsl'
+
+// querydsl QClass 파일 생성 위치를 지정
+tasks.withType(JavaCompile) {
+    options.getGeneratedSourceOutputDirectory().set(file(generated))
+}
+
+// java source set 에 querydsl QClass 위치 추가
+sourceSets {
+    main.java.srcDirs += [generated]
+}
+
+// gradle clean 시에 QClass 디렉토리 삭제
+clean {
+    delete file(generated)
+}
+
+/** QueryDSL end **/

--- a/http-test/sale/sales-order-test.http
+++ b/http-test/sale/sales-order-test.http
@@ -4,6 +4,11 @@ Content-Type: application/json
 
 {
   "userToken": "fwee112f3gb6bny5",
-  "salesQuantity": 10.2,
+  "salesQuantity": 25.21,
   "type": "금 99.9%"
 }
+
+### 판매목록 조회
+GET http://localhost:9999/api/sales-order/history?userToken=fwee112f3gb6bny5
+Content-Type: application/json
+

--- a/src/main/java/wanted/goldroom/product/application/sale/SaleFacade.java
+++ b/src/main/java/wanted/goldroom/product/application/sale/SaleFacade.java
@@ -10,6 +10,7 @@ import wanted.goldroom.product.domain.price.PriceService;
 import wanted.goldroom.product.domain.sale.SaleCommand;
 import wanted.goldroom.product.domain.sale.SaleInfo;
 import wanted.goldroom.product.domain.sale.SaleService;
+import wanted.goldroom.product.infrastructure.common.util.CustomSlice;
 
 @Service
 @RequiredArgsConstructor
@@ -23,5 +24,9 @@ public class SaleFacade {
         Item item = itemService.findByType(type);
         Price price = priceService.findLatestPrice();
         return saleService.registerSale(command, item, price);
+    }
+
+    public CustomSlice<SaleInfo.DetailSaleOrders> detailsSaleOrders(SaleCommand.DetailSalesOrders command) {
+        return saleService.detailsSales(command);
     }
 }

--- a/src/main/java/wanted/goldroom/product/domain/sale/SaleCommand.java
+++ b/src/main/java/wanted/goldroom/product/domain/sale/SaleCommand.java
@@ -1,5 +1,7 @@
 package wanted.goldroom.product.domain.sale;
 
+import java.time.LocalDateTime;
+
 import wanted.goldroom.product.domain.item.Item;
 
 public class SaleCommand {
@@ -18,5 +20,13 @@ public class SaleCommand {
                 .salePrice(salePrice)
                 .build();
         }
+    }
+
+    public record DetailSalesOrders(
+        String userToken,
+        int size,
+        LocalDateTime cursor
+    ) {
+
     }
 }

--- a/src/main/java/wanted/goldroom/product/domain/sale/SaleInfo.java
+++ b/src/main/java/wanted/goldroom/product/domain/sale/SaleInfo.java
@@ -1,5 +1,10 @@
 package wanted.goldroom.product.domain.sale;
 
+import java.time.LocalDateTime;
+
+import lombok.Getter;
+import wanted.goldroom.product.domain.item.Item;
+
 public class SaleInfo {
 
     public record RegisterSaleInfo(
@@ -9,5 +14,16 @@ public class SaleInfo {
         public static RegisterSaleInfo from(Sale sale) {
             return new RegisterSaleInfo(sale.getOrderNo());
         }
+    }
+
+    @Getter
+    public static class DetailSaleOrders {
+        private String orderNo;
+        private LocalDateTime createdAt;
+        private String seller;
+        private Sale.Status status;
+        private Item.Type type;
+        private double saleQuantity;
+        private int amount;
     }
 }

--- a/src/main/java/wanted/goldroom/product/domain/sale/SaleReader.java
+++ b/src/main/java/wanted/goldroom/product/domain/sale/SaleReader.java
@@ -1,0 +1,10 @@
+package wanted.goldroom.product.domain.sale;
+
+import java.time.LocalDateTime;
+
+import wanted.goldroom.product.infrastructure.common.util.CustomSlice;
+
+public interface SaleReader {
+
+    CustomSlice<SaleInfo.DetailSaleOrders> findAllDetails(String userToken, int size, LocalDateTime cursor);
+}

--- a/src/main/java/wanted/goldroom/product/domain/sale/SaleService.java
+++ b/src/main/java/wanted/goldroom/product/domain/sale/SaleService.java
@@ -2,8 +2,11 @@ package wanted.goldroom.product.domain.sale;
 
 import wanted.goldroom.product.domain.item.Item;
 import wanted.goldroom.product.domain.price.Price;
+import wanted.goldroom.product.infrastructure.common.util.CustomSlice;
 
 public interface SaleService {
 
     SaleInfo.RegisterSaleInfo registerSale(SaleCommand.RegisterSalesOrder command, Item item, Price price);
+
+    CustomSlice<SaleInfo.DetailSaleOrders> detailsSales(SaleCommand.DetailSalesOrders command);
 }

--- a/src/main/java/wanted/goldroom/product/domain/sale/SaleServiceImpl.java
+++ b/src/main/java/wanted/goldroom/product/domain/sale/SaleServiceImpl.java
@@ -6,11 +6,14 @@ import org.springframework.transaction.annotation.Transactional;
 import lombok.RequiredArgsConstructor;
 import wanted.goldroom.product.domain.item.Item;
 import wanted.goldroom.product.domain.price.Price;
+import wanted.goldroom.product.infrastructure.common.util.CustomSlice;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class SaleServiceImpl implements SaleService {
     private final SaleStore saleStore;
+    private final SaleReader saleReader;
 
     @Override
     @Transactional
@@ -18,5 +21,10 @@ public class SaleServiceImpl implements SaleService {
         Item item, Price price) {
         Sale sale = saleStore.store(command.toEntity(item, price.getSalePrice()));
         return SaleInfo.RegisterSaleInfo.from(sale);
+    }
+
+    @Override
+    public CustomSlice<SaleInfo.DetailSaleOrders> detailsSales(SaleCommand.DetailSalesOrders command) {
+        return saleReader.findAllDetails(command.userToken(), command.size(), command.cursor());
     }
 }

--- a/src/main/java/wanted/goldroom/product/infrastructure/common/config/QueryDslConfig.java
+++ b/src/main/java/wanted/goldroom/product/infrastructure/common/config/QueryDslConfig.java
@@ -1,0 +1,17 @@
+package wanted.goldroom.product.infrastructure.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import jakarta.persistence.EntityManager;
+
+@Configuration
+public class QueryDslConfig {
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory(EntityManager em) {
+        return new JPAQueryFactory(em);
+    }
+}

--- a/src/main/java/wanted/goldroom/product/infrastructure/common/util/CustomSlice.java
+++ b/src/main/java/wanted/goldroom/product/infrastructure/common/util/CustomSlice.java
@@ -1,0 +1,28 @@
+package wanted.goldroom.product.infrastructure.common.util;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import lombok.Getter;
+
+@Getter
+public class CustomSlice<T> {
+    private final static boolean IS_EMPTY = false;
+    private final static boolean IS_NOT_EMPTY = true;
+
+    private final boolean success;
+    private final String message;
+    private final List<T> data;
+    private final Paging links;
+
+    public CustomSlice(List<T> data, LocalDateTime nextCursor, boolean hasNext) {
+        this.success = data.isEmpty() ? IS_EMPTY : IS_NOT_EMPTY;
+        this.message = data.isEmpty() ? "Empty to search invoices" : "Success to search invoices";
+        this.data = data;
+        this.links = new Paging(nextCursor, hasNext);
+    }
+
+    public record Paging(LocalDateTime nextCursor, boolean hasNext) {
+
+    }
+}

--- a/src/main/java/wanted/goldroom/product/infrastructure/common/util/PaginationUtil.java
+++ b/src/main/java/wanted/goldroom/product/infrastructure/common/util/PaginationUtil.java
@@ -1,0 +1,21 @@
+package wanted.goldroom.product.infrastructure.common.util;
+
+import java.util.List;
+
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.SliceImpl;
+
+public class PaginationUtil<T> {
+
+    public static <T> SliceImpl<T> checkLastPage(int size, List<T> results) {
+
+        boolean hasNext = false;
+
+        if (results.size() > size) {
+            hasNext = true;
+            results.remove(size);
+        }
+
+        return new SliceImpl<>(results, PageRequest.ofSize(size), hasNext);
+    }
+}

--- a/src/main/java/wanted/goldroom/product/infrastructure/sale/SalePaginationRepository.java
+++ b/src/main/java/wanted/goldroom/product/infrastructure/sale/SalePaginationRepository.java
@@ -1,0 +1,43 @@
+package wanted.goldroom.product.infrastructure.sale;
+
+import static wanted.goldroom.product.domain.sale.QSale.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.springframework.data.domain.Slice;
+import org.springframework.stereotype.Repository;
+
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import lombok.RequiredArgsConstructor;
+import wanted.goldroom.product.domain.sale.SaleInfo;
+import wanted.goldroom.product.infrastructure.common.util.PaginationUtil;
+
+@Repository
+@RequiredArgsConstructor
+public class SalePaginationRepository {
+    private final SaleRepository saleRepository;
+    private final JPAQueryFactory queryFactory;
+
+    public Slice<SaleInfo.DetailSaleOrders> findByUserToken(String userToken, int size, LocalDateTime cursor) {
+        List<SaleInfo.DetailSaleOrders> orders = queryFactory.select(
+                Projections.fields(SaleInfo.DetailSaleOrders.class,
+                    sale.orderNo,
+                    sale.createdAt,
+                    sale.seller.as("userToken"),
+                    sale.status,
+                    sale.item.type,
+                    sale.saleQuantity,
+                    sale.amount))
+            .from(sale)
+            .where(
+                saleRepository.lessThanCreatedAt(cursor),
+                saleRepository.equalUserToken(userToken))
+            .orderBy(sale.createdAt.desc())
+            .limit(size + 1)
+            .fetch();
+        return PaginationUtil.checkLastPage(size, orders);
+    }
+}

--- a/src/main/java/wanted/goldroom/product/infrastructure/sale/SaleReaderImpl.java
+++ b/src/main/java/wanted/goldroom/product/infrastructure/sale/SaleReaderImpl.java
@@ -1,0 +1,31 @@
+package wanted.goldroom.product.infrastructure.sale;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.springframework.data.domain.Slice;
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+import wanted.goldroom.product.domain.sale.SaleInfo;
+import wanted.goldroom.product.domain.sale.SaleReader;
+import wanted.goldroom.product.infrastructure.common.util.CustomSlice;
+
+@Component
+@RequiredArgsConstructor
+public class SaleReaderImpl implements SaleReader {
+    private final SalePaginationRepository paginationRepository;
+
+    @Override
+    public CustomSlice<SaleInfo.DetailSaleOrders> findAllDetails(String userToken, int size,
+        LocalDateTime cursor) {
+        Slice<SaleInfo.DetailSaleOrders> paginationList
+            = paginationRepository.findByUserToken(userToken, size, cursor);
+
+        List<SaleInfo.DetailSaleOrders> orders = paginationList.getContent();
+        LocalDateTime nextCursor = orders.isEmpty() ? null : orders.get(orders.size() - 1).getCreatedAt();
+
+        return new CustomSlice<>(orders, nextCursor, paginationList.hasNext());
+
+    }
+}

--- a/src/main/java/wanted/goldroom/product/infrastructure/sale/SaleRepository.java
+++ b/src/main/java/wanted/goldroom/product/infrastructure/sale/SaleRepository.java
@@ -1,8 +1,29 @@
 package wanted.goldroom.product.infrastructure.sale;
 
+import static wanted.goldroom.product.domain.sale.QSale.*;
+
+import java.time.LocalDateTime;
+
 import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
 
 import wanted.goldroom.product.domain.sale.Sale;
 
 public interface SaleRepository extends JpaRepository<Sale, String> {
+
+    default BooleanExpression lessThanCreatedAt(LocalDateTime createdAt) {
+        if (createdAt == null) {
+            return null;
+        }
+
+        return sale.createdAt.loe(createdAt);
+    }
+
+    default BooleanExpression equalUserToken(String userToken) {
+        if (userToken == null) {
+            return null;
+        }
+        return sale.seller.eq(userToken);
+    }
 }

--- a/src/main/java/wanted/goldroom/product/interfaces/sale/SaleController.java
+++ b/src/main/java/wanted/goldroom/product/interfaces/sale/SaleController.java
@@ -1,9 +1,13 @@
 package wanted.goldroom.product.interfaces.sale;
 
+import java.time.LocalDateTime;
+
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import jakarta.validation.Valid;
@@ -11,6 +15,7 @@ import lombok.RequiredArgsConstructor;
 import wanted.goldroom.product.application.sale.SaleFacade;
 import wanted.goldroom.product.domain.sale.SaleCommand;
 import wanted.goldroom.product.domain.sale.SaleInfo;
+import wanted.goldroom.product.infrastructure.common.util.CustomSlice;
 
 @RestController
 @RequiredArgsConstructor
@@ -26,5 +31,14 @@ public class SaleController {
         SaleInfo.RegisterSaleInfo info = saleFacade.registerSale(command);
         SaleDto.RegisterSaleOrderResponse response = mapper.of(info);
         return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/history")
+    public ResponseEntity<CustomSlice<SaleInfo.DetailSaleOrders>> detailsSalesOrders(
+        @RequestParam(name = "userToken") String userToken,
+        @RequestParam(required = false, defaultValue = "10") int size,
+        @RequestParam(required = false) LocalDateTime cursor) {
+        SaleCommand.DetailSalesOrders command = mapper.of(userToken, size, cursor);
+        return ResponseEntity.ok(saleFacade.detailsSaleOrders(command));
     }
 }

--- a/src/main/java/wanted/goldroom/product/interfaces/sale/SaleDtoMapper.java
+++ b/src/main/java/wanted/goldroom/product/interfaces/sale/SaleDtoMapper.java
@@ -1,5 +1,7 @@
 package wanted.goldroom.product.interfaces.sale;
 
+import java.time.LocalDateTime;
+
 import org.mapstruct.InjectionStrategy;
 import org.mapstruct.Mapper;
 import org.mapstruct.ReportingPolicy;
@@ -16,4 +18,6 @@ public interface SaleDtoMapper {
     SaleCommand.RegisterSalesOrder of(SaleDto.RegisterSaleOrderRequest request);
 
     SaleDto.RegisterSaleOrderResponse of(SaleInfo.RegisterSaleInfo info);
+
+    SaleCommand.DetailSalesOrders of(String userToken, int size, LocalDateTime cursor);
 }


### PR DESCRIPTION
## Issue
- #5 

## PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 반영 브랜치
ex) feat/dales_details -> main

## 변경 사항
- 판매내역 조회 기능을 구현했습니다. 
  - querydsl을 사용하여 pagination을 구현했습니다.
  - .http파일을 이용하여 api 테스트를 진행했습니다.

## 테스트 결과
### Request
```java
HTTP : GET
URL: /api/sales-order/history?userToken=""&cursor=""&size=""
```

### Response : 성공시
`HTTP/1.1 200`
```
{
  "success": true,
  "message": "Success to search invoices",
  "data": [
    {
      "orderNo": "20240910163124_16MVusOiDl",
      "createdAt": "2024-09-10T16:31:27",
      "seller": null,
      "status": "ORDER_COMPLETE",
      "type": "GOLD_99_9_PERCENT",
      "saleQuantity": 11.23,
      "amount": 10107
    }
  ],
  "links": {
    "nextCursor": "2024-09-10T16:31:27",
    "hasNext": false
  }
}
```

### Response : 실패 시 [판매 내역이 없을 때 ]
```
{
  "success": false,
  "message": "Empty to search invoices",
  "data": [],
  "links": {
    "nextCursor": null,
    "hasNext": false
  }
}
```
### CheckPoint
- querydsl을 이용해 해당 userToken 정보만 볼 수 있도록 구현했기 때문에 별도의 예외처리는 하지 않았습니다.
- 판매 내역이 없을 때는 해당 요청은 제대로 수행했기 때문에 HttpStatus Code는 200을 주었습니다.