### PR TITLE
[feat] 판매내역 상세 조회 기능 구현

### DIFF
--- a/http-test/sale/sales-order-test.http
+++ b/http-test/sale/sales-order-test.http
@@ -9,7 +9,7 @@ Content-Type: application/json
 }
 
 ### 판매목록 조회
-GET http://localhost:9999/api/sales-order/history?userToken=fwee112f3gb6bny5
+GET http://localhost:9999/api/sales-order/history/list?userToken=fwee112f3gb6bny5
 Content-Type: application/json
 
 ### 판매 상세 조회

--- a/http-test/sale/sales-order-test.http
+++ b/http-test/sale/sales-order-test.http
@@ -12,3 +12,6 @@ Content-Type: application/json
 GET http://localhost:9999/api/sales-order/history?userToken=fwee112f3gb6bny5
 Content-Type: application/json
 
+### 판매 상세 조회
+GET http://localhost:9999/api/sales-order/history?orderNo=20240909205003_d6aLfGvLfy
+Content-Type: application/json

--- a/src/main/java/wanted/goldroom/product/application/sale/SaleFacade.java
+++ b/src/main/java/wanted/goldroom/product/application/sale/SaleFacade.java
@@ -26,7 +26,7 @@ public class SaleFacade {
         return saleService.registerSale(command, item, price);
     }
 
-    public CustomSlice<SaleInfo.DetailSaleOrderList> detailsSaleOrders(SaleCommand.DetailSalesOrders command) {
+    public CustomSlice<SaleInfo.DetailSaleOrderList> detailsSaleOrders(SaleCommand.DetailSalesOrderList command) {
         return saleService.detailsSaleList(command);
     }
 

--- a/src/main/java/wanted/goldroom/product/application/sale/SaleFacade.java
+++ b/src/main/java/wanted/goldroom/product/application/sale/SaleFacade.java
@@ -26,7 +26,7 @@ public class SaleFacade {
         return saleService.registerSale(command, item, price);
     }
 
-    public CustomSlice<SaleInfo.DetailSaleOrders> detailsSaleOrders(SaleCommand.DetailSalesOrders command) {
-        return saleService.detailsSales(command);
+    public CustomSlice<SaleInfo.DetailSaleOrders> detailsSaleOrderList(SaleCommand.DetailSalesOrderList command) {
+        return saleService.detailsSaleList(command);
     }
 }

--- a/src/main/java/wanted/goldroom/product/application/sale/SaleFacade.java
+++ b/src/main/java/wanted/goldroom/product/application/sale/SaleFacade.java
@@ -26,7 +26,11 @@ public class SaleFacade {
         return saleService.registerSale(command, item, price);
     }
 
-    public CustomSlice<SaleInfo.DetailSaleOrders> detailsSaleOrderList(SaleCommand.DetailSalesOrderList command) {
+    public CustomSlice<SaleInfo.DetailSaleOrderList> detailsSaleOrderList(SaleCommand.DetailSalesOrderList command) {
         return saleService.detailsSaleList(command);
+    }
+
+    public SaleInfo.DetailSaleOrder detailsSaleOrder(SaleCommand.DetailSalesOrder command) {
+        return saleService.detailsSale(command);
     }
 }

--- a/src/main/java/wanted/goldroom/product/domain/exception/ErrorCode.java
+++ b/src/main/java/wanted/goldroom/product/domain/exception/ErrorCode.java
@@ -13,7 +13,10 @@ public enum ErrorCode {
     NOT_FOUND_ITEM("상품을 찾을 수 없습니다."),
 
     // PRICE
-    NOT_FOUND_PRICE("가격정보를 찾을 수 없습니다.");
+    NOT_FOUND_PRICE("가격정보를 찾을 수 없습니다."),
+
+    // ORDER
+    NOT_FOUND_ORDER("해당 정보를 가져올 수 없습니다.");
 
     private final String message;
 }

--- a/src/main/java/wanted/goldroom/product/domain/sale/SaleCommand.java
+++ b/src/main/java/wanted/goldroom/product/domain/sale/SaleCommand.java
@@ -22,7 +22,7 @@ public class SaleCommand {
         }
     }
 
-    public record DetailSalesOrders(
+    public record DetailSalesOrderList(
         String userToken,
         int size,
         LocalDateTime cursor

--- a/src/main/java/wanted/goldroom/product/domain/sale/SaleCommand.java
+++ b/src/main/java/wanted/goldroom/product/domain/sale/SaleCommand.java
@@ -29,4 +29,10 @@ public class SaleCommand {
     ) {
 
     }
+
+    public record DetailSalesOrder(
+        String orderNo
+    ) {
+
+    }
 }

--- a/src/main/java/wanted/goldroom/product/domain/sale/SaleInfo.java
+++ b/src/main/java/wanted/goldroom/product/domain/sale/SaleInfo.java
@@ -26,4 +26,25 @@ public class SaleInfo {
         private double saleQuantity;
         private int amount;
     }
+
+    public record DetailSaleOrder(
+        String orderNo,
+        LocalDateTime createdAt,
+        String seller,
+        String status,
+        Item.Type type,
+        double saleQuantity,
+        int amount
+    ) {
+
+        public DetailSaleOrder(Sale sale) {
+            this(sale.getOrderNo(),
+                sale.getCreatedAt(),
+                sale.getSeller(),
+                sale.getStatus().getDescription(),
+                sale.getItem().getType(),
+                sale.getSaleQuantity(),
+                sale.getAmount());
+        }
+    }
 }

--- a/src/main/java/wanted/goldroom/product/domain/sale/SaleInfo.java
+++ b/src/main/java/wanted/goldroom/product/domain/sale/SaleInfo.java
@@ -32,7 +32,7 @@ public class SaleInfo {
         LocalDateTime createdAt,
         String seller,
         String status,
-        Item.Type type,
+        String type,
         double saleQuantity,
         int amount
     ) {
@@ -42,7 +42,7 @@ public class SaleInfo {
                 sale.getCreatedAt(),
                 sale.getSeller(),
                 sale.getStatus().getDescription(),
-                sale.getItem().getType(),
+                sale.getItem().getType().getProduct(),
                 sale.getSaleQuantity(),
                 sale.getAmount());
         }

--- a/src/main/java/wanted/goldroom/product/domain/sale/SaleInfo.java
+++ b/src/main/java/wanted/goldroom/product/domain/sale/SaleInfo.java
@@ -17,7 +17,7 @@ public class SaleInfo {
     }
 
     @Getter
-    public static class DetailSaleOrders {
+    public static class DetailSaleOrderList {
         private String orderNo;
         private LocalDateTime createdAt;
         private String seller;

--- a/src/main/java/wanted/goldroom/product/domain/sale/SaleReader.java
+++ b/src/main/java/wanted/goldroom/product/domain/sale/SaleReader.java
@@ -7,4 +7,6 @@ import wanted.goldroom.product.infrastructure.common.util.CustomSlice;
 public interface SaleReader {
 
     CustomSlice<SaleInfo.DetailSaleOrderList> findAllDetails(String userToken, int size, LocalDateTime cursor);
+
+    SaleInfo.DetailSaleOrder findSaleDetails(String orderNo);
 }

--- a/src/main/java/wanted/goldroom/product/domain/sale/SaleReader.java
+++ b/src/main/java/wanted/goldroom/product/domain/sale/SaleReader.java
@@ -6,5 +6,5 @@ import wanted.goldroom.product.infrastructure.common.util.CustomSlice;
 
 public interface SaleReader {
 
-    CustomSlice<SaleInfo.DetailSaleOrders> findAllDetails(String userToken, int size, LocalDateTime cursor);
+    CustomSlice<SaleInfo.DetailSaleOrderList> findAllDetails(String userToken, int size, LocalDateTime cursor);
 }

--- a/src/main/java/wanted/goldroom/product/domain/sale/SaleService.java
+++ b/src/main/java/wanted/goldroom/product/domain/sale/SaleService.java
@@ -8,5 +8,5 @@ public interface SaleService {
 
     SaleInfo.RegisterSaleInfo registerSale(SaleCommand.RegisterSalesOrder command, Item item, Price price);
 
-    CustomSlice<SaleInfo.DetailSaleOrders> detailsSaleList(SaleCommand.DetailSalesOrderList command);
+    CustomSlice<SaleInfo.DetailSaleOrderList> detailsSaleList(SaleCommand.DetailSalesOrderList command);
 }

--- a/src/main/java/wanted/goldroom/product/domain/sale/SaleService.java
+++ b/src/main/java/wanted/goldroom/product/domain/sale/SaleService.java
@@ -9,4 +9,6 @@ public interface SaleService {
     SaleInfo.RegisterSaleInfo registerSale(SaleCommand.RegisterSalesOrder command, Item item, Price price);
 
     CustomSlice<SaleInfo.DetailSaleOrderList> detailsSaleList(SaleCommand.DetailSalesOrderList command);
+
+    SaleInfo.DetailSaleOrder detailsSale(SaleCommand.DetailSalesOrder command);
 }

--- a/src/main/java/wanted/goldroom/product/domain/sale/SaleService.java
+++ b/src/main/java/wanted/goldroom/product/domain/sale/SaleService.java
@@ -8,5 +8,5 @@ public interface SaleService {
 
     SaleInfo.RegisterSaleInfo registerSale(SaleCommand.RegisterSalesOrder command, Item item, Price price);
 
-    CustomSlice<SaleInfo.DetailSaleOrders> detailsSales(SaleCommand.DetailSalesOrders command);
+    CustomSlice<SaleInfo.DetailSaleOrders> detailsSaleList(SaleCommand.DetailSalesOrderList command);
 }

--- a/src/main/java/wanted/goldroom/product/domain/sale/SaleServiceImpl.java
+++ b/src/main/java/wanted/goldroom/product/domain/sale/SaleServiceImpl.java
@@ -24,7 +24,7 @@ public class SaleServiceImpl implements SaleService {
     }
 
     @Override
-    public CustomSlice<SaleInfo.DetailSaleOrders> detailsSales(SaleCommand.DetailSalesOrders command) {
+    public CustomSlice<SaleInfo.DetailSaleOrders> detailsSaleList(SaleCommand.DetailSalesOrderList command) {
         return saleReader.findAllDetails(command.userToken(), command.size(), command.cursor());
     }
 }

--- a/src/main/java/wanted/goldroom/product/domain/sale/SaleServiceImpl.java
+++ b/src/main/java/wanted/goldroom/product/domain/sale/SaleServiceImpl.java
@@ -24,7 +24,7 @@ public class SaleServiceImpl implements SaleService {
     }
 
     @Override
-    public CustomSlice<SaleInfo.DetailSaleOrders> detailsSaleList(SaleCommand.DetailSalesOrderList command) {
+    public CustomSlice<SaleInfo.DetailSaleOrderList> detailsSaleList(SaleCommand.DetailSalesOrderList command) {
         return saleReader.findAllDetails(command.userToken(), command.size(), command.cursor());
     }
 }

--- a/src/main/java/wanted/goldroom/product/domain/sale/SaleServiceImpl.java
+++ b/src/main/java/wanted/goldroom/product/domain/sale/SaleServiceImpl.java
@@ -27,4 +27,9 @@ public class SaleServiceImpl implements SaleService {
     public CustomSlice<SaleInfo.DetailSaleOrderList> detailsSaleList(SaleCommand.DetailSalesOrderList command) {
         return saleReader.findAllDetails(command.userToken(), command.size(), command.cursor());
     }
+
+    @Override
+    public SaleInfo.DetailSaleOrder detailsSale(SaleCommand.DetailSalesOrder command) {
+        return saleReader.findSaleDetails(command.orderNo());
+    }
 }

--- a/src/main/java/wanted/goldroom/product/infrastructure/sale/SalePaginationRepository.java
+++ b/src/main/java/wanted/goldroom/product/infrastructure/sale/SalePaginationRepository.java
@@ -21,9 +21,9 @@ public class SalePaginationRepository {
     private final SaleRepository saleRepository;
     private final JPAQueryFactory queryFactory;
 
-    public Slice<SaleInfo.DetailSaleOrders> findByUserToken(String userToken, int size, LocalDateTime cursor) {
-        List<SaleInfo.DetailSaleOrders> orders = queryFactory.select(
-                Projections.fields(SaleInfo.DetailSaleOrders.class,
+    public Slice<SaleInfo.DetailSaleOrderList> findByUserToken(String userToken, int size, LocalDateTime cursor) {
+        List<SaleInfo.DetailSaleOrderList> orders = queryFactory.select(
+                Projections.fields(SaleInfo.DetailSaleOrderList.class,
                     sale.orderNo,
                     sale.createdAt,
                     sale.seller.as("userToken"),

--- a/src/main/java/wanted/goldroom/product/infrastructure/sale/SaleReaderImpl.java
+++ b/src/main/java/wanted/goldroom/product/infrastructure/sale/SaleReaderImpl.java
@@ -17,12 +17,12 @@ public class SaleReaderImpl implements SaleReader {
     private final SalePaginationRepository paginationRepository;
 
     @Override
-    public CustomSlice<SaleInfo.DetailSaleOrders> findAllDetails(String userToken, int size,
+    public CustomSlice<SaleInfo.DetailSaleOrderList> findAllDetails(String userToken, int size,
         LocalDateTime cursor) {
-        Slice<SaleInfo.DetailSaleOrders> paginationList
+        Slice<SaleInfo.DetailSaleOrderList> paginationList
             = paginationRepository.findByUserToken(userToken, size, cursor);
 
-        List<SaleInfo.DetailSaleOrders> orders = paginationList.getContent();
+        List<SaleInfo.DetailSaleOrderList> orders = paginationList.getContent();
         LocalDateTime nextCursor = orders.isEmpty() ? null : orders.get(orders.size() - 1).getCreatedAt();
 
         return new CustomSlice<>(orders, nextCursor, paginationList.hasNext());

--- a/src/main/java/wanted/goldroom/product/infrastructure/sale/SaleReaderImpl.java
+++ b/src/main/java/wanted/goldroom/product/infrastructure/sale/SaleReaderImpl.java
@@ -7,6 +7,9 @@ import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Component;
 
 import lombok.RequiredArgsConstructor;
+import wanted.goldroom.product.domain.exception.ErrorCode;
+import wanted.goldroom.product.domain.exception.NotFoundException;
+import wanted.goldroom.product.domain.sale.Sale;
 import wanted.goldroom.product.domain.sale.SaleInfo;
 import wanted.goldroom.product.domain.sale.SaleReader;
 import wanted.goldroom.product.infrastructure.common.util.CustomSlice;
@@ -15,6 +18,7 @@ import wanted.goldroom.product.infrastructure.common.util.CustomSlice;
 @RequiredArgsConstructor
 public class SaleReaderImpl implements SaleReader {
     private final SalePaginationRepository paginationRepository;
+    private final SaleRepository saleRepository;
 
     @Override
     public CustomSlice<SaleInfo.DetailSaleOrderList> findAllDetails(String userToken, int size,
@@ -26,6 +30,12 @@ public class SaleReaderImpl implements SaleReader {
         LocalDateTime nextCursor = orders.isEmpty() ? null : orders.get(orders.size() - 1).getCreatedAt();
 
         return new CustomSlice<>(orders, nextCursor, paginationList.hasNext());
+    }
 
+    @Override
+    public SaleInfo.DetailSaleOrder findSaleDetails(String orderNo) {
+        Sale sale = saleRepository.findByOrderNo(orderNo)
+            .orElseThrow(() -> new NotFoundException(ErrorCode.NOT_FOUND_ORDER));
+        return new SaleInfo.DetailSaleOrder(sale);
     }
 }

--- a/src/main/java/wanted/goldroom/product/infrastructure/sale/SaleRepository.java
+++ b/src/main/java/wanted/goldroom/product/infrastructure/sale/SaleRepository.java
@@ -3,6 +3,7 @@ package wanted.goldroom.product.infrastructure.sale;
 import static wanted.goldroom.product.domain.sale.QSale.*;
 
 import java.time.LocalDateTime;
+import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -11,6 +12,8 @@ import com.querydsl.core.types.dsl.BooleanExpression;
 import wanted.goldroom.product.domain.sale.Sale;
 
 public interface SaleRepository extends JpaRepository<Sale, String> {
+
+    Optional<Sale> findByOrderNo(String orderNo);
 
     default BooleanExpression lessThanCreatedAt(LocalDateTime createdAt) {
         if (createdAt == null) {

--- a/src/main/java/wanted/goldroom/product/interfaces/sale/SaleController.java
+++ b/src/main/java/wanted/goldroom/product/interfaces/sale/SaleController.java
@@ -38,7 +38,7 @@ public class SaleController {
         @RequestParam(name = "userToken") String userToken,
         @RequestParam(required = false, defaultValue = "10") int size,
         @RequestParam(required = false) LocalDateTime cursor) {
-        SaleCommand.DetailSalesOrders command = mapper.of(userToken, size, cursor);
+        SaleCommand.DetailSalesOrderList command = mapper.of(userToken, size, cursor);
         CustomSlice<SaleInfo.DetailSaleOrderList> info = saleFacade.detailsSaleOrders(command);
         var response = info.map(SaleDto.DetailsSaleOrderListResponse::from);
         return ResponseEntity.ok(response);

--- a/src/main/java/wanted/goldroom/product/interfaces/sale/SaleController.java
+++ b/src/main/java/wanted/goldroom/product/interfaces/sale/SaleController.java
@@ -33,12 +33,21 @@ public class SaleController {
         return ResponseEntity.ok(response);
     }
 
-    @GetMapping("/history")
-    public ResponseEntity<CustomSlice<SaleInfo.DetailSaleOrders>> detailsSalesOrders(
-        @RequestParam(name = "userToken") String userToken,
+    @GetMapping("/history/list")
+    public ResponseEntity<CustomSlice<SaleInfo.DetailSaleOrderList>> detailsSalesOrderList(
+        @RequestParam String userToken,
         @RequestParam(required = false, defaultValue = "10") int size,
         @RequestParam(required = false) LocalDateTime cursor) {
-        SaleCommand.DetailSalesOrders command = mapper.of(userToken, size, cursor);
-        return ResponseEntity.ok(saleFacade.detailsSaleOrders(command));
+        SaleCommand.DetailSalesOrderList command = mapper.of(userToken, size, cursor);
+        return ResponseEntity.ok(saleFacade.detailsSaleOrderList(command));
+    }
+
+    @GetMapping("/history")
+    public ResponseEntity<SaleDto.DetailsSaleOrderResponse> detailsSalesOrder(
+        @RequestParam String orderNo) {
+        SaleCommand.DetailSalesOrder command = mapper.of(orderNo);
+        SaleInfo.DetailSaleOrder info = saleFacade.detailsSaleOrder(command);
+        SaleDto.DetailsSaleOrderResponse response = mapper.of(info);
+        return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/wanted/goldroom/product/interfaces/sale/SaleDto.java
+++ b/src/main/java/wanted/goldroom/product/interfaces/sale/SaleDto.java
@@ -46,4 +46,16 @@ public class SaleDto {
                 list.amount());
         }
     }
+
+    public record DetailsSaleOrderResponse(
+        String orderNo,
+        LocalDateTime createdAt,
+        String seller,
+        String status,
+        String type,
+        double saleQuantity,
+        int amount
+    ) {
+
+    }
 }

--- a/src/main/java/wanted/goldroom/product/interfaces/sale/SaleDto.java
+++ b/src/main/java/wanted/goldroom/product/interfaces/sale/SaleDto.java
@@ -1,5 +1,7 @@
 package wanted.goldroom.product.interfaces.sale;
 
+import java.time.LocalDateTime;
+
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
@@ -18,6 +20,18 @@ public class SaleDto {
 
     public record RegisterSaleOrderResponse(
         String orderNo
+    ) {
+
+    }
+
+    public record DetailsSaleOrderResponse(
+        String orderNo,
+        LocalDateTime createdAt,
+        String seller,
+        String status,
+        String type,
+        double saleQuantity,
+        int amount
     ) {
 
     }

--- a/src/main/java/wanted/goldroom/product/interfaces/sale/SaleDtoMapper.java
+++ b/src/main/java/wanted/goldroom/product/interfaces/sale/SaleDtoMapper.java
@@ -19,5 +19,5 @@ public interface SaleDtoMapper {
 
     SaleDto.RegisterSaleOrderResponse of(SaleInfo.RegisterSaleInfo info);
 
-    SaleCommand.DetailSalesOrders of(String userToken, int size, LocalDateTime cursor);
+    SaleCommand.DetailSalesOrderList of(String userToken, int size, LocalDateTime cursor);
 }

--- a/src/main/java/wanted/goldroom/product/interfaces/sale/SaleDtoMapper.java
+++ b/src/main/java/wanted/goldroom/product/interfaces/sale/SaleDtoMapper.java
@@ -20,4 +20,8 @@ public interface SaleDtoMapper {
     SaleDto.RegisterSaleOrderResponse of(SaleInfo.RegisterSaleInfo info);
 
     SaleCommand.DetailSalesOrderList of(String userToken, int size, LocalDateTime cursor);
+
+    SaleCommand.DetailSalesOrder of(String orderNo);
+
+    SaleDto.DetailsSaleOrderResponse of(SaleInfo.DetailSaleOrder info);
 }


### PR DESCRIPTION
## Issue
- #7 

## PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 반영 브랜치
ex) feat/sales_detail -> main

## 변경 사항
- 판매내역 상세 조회 기능을 구현했습니다.
  - .http파일을 이용하여 api 테스트를 진행했습니다.

## 테스트 결과
### Request
```java
HTTP : GET
URL: /api/sales-order/history?userToken=""&cursor=""&size=""
```

### Response : 성공시
`HTTP/1.1 200`
```
{
  "orderNo": "20240909205003_d6aLfGvLfy",
  "createdAt": "2024-09-09T20:50:18",
  "seller": "fwee112f3gb6bny5",
  "status": "주문 완료",
  "type": "금 99.9%",
  "saleQuantity": 10.2,
  "amount": 9180
}
```

### Response : 실패 시 [잘못된 order number를 넘겼을 때]
`HTTP/1.1 404`
```
{
  "statusCode": 404,
  "message": "해당 정보를 가져올 수 없습니다."
}
```